### PR TITLE
feat:TweenProviderの実装

### DIFF
--- a/MittaUI.Runtime/Extension/CanvasGroupExtensions.cs
+++ b/MittaUI.Runtime/Extension/CanvasGroupExtensions.cs
@@ -1,4 +1,5 @@
 using Cysharp.Threading.Tasks;
+using MittaUI.Runtime.TweenProvider;
 using UnityEngine;
 
 namespace MittaUI.Runtime.Extension
@@ -17,7 +18,7 @@ namespace MittaUI.Runtime.Extension
             canvasGroup.interactable = true;
             canvasGroup.blocksRaycasts = true;
             // TODO : アニメーション実装
-            //await canvasGroup.DOFade(1f, fadeDuration);
+            await canvasGroup.FadeAsync(1f, fadeDuration);
         }
 
         public static void Disable(this CanvasGroup canvasGroup)
@@ -32,7 +33,7 @@ namespace MittaUI.Runtime.Extension
             canvasGroup.interactable = false;
             canvasGroup.blocksRaycasts = false;
             // TODO : アニメーション実装
-            //await canvasGroup.DOFade(0f, fadeDuration);
+            await canvasGroup.FadeAsync(0f, fadeDuration);
         }
     }
 }

--- a/MittaUI.Runtime/Extension/GraphicExteinsion.cs
+++ b/MittaUI.Runtime/Extension/GraphicExteinsion.cs
@@ -1,14 +1,17 @@
-#if MITTAUI_USE_UPALETTE
-
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
+#if MITTAUI_USE_UPALETTE
 using uPalette.Runtime.Core;
+#endif
 
 namespace MittaUI.Runtime.Extension
 {
     /// <summary>Graphicの拡張</summary>
     public static class GraphicExtensions
     {
+
+#if MITTAUI_USE_UPALETTE
         /// <summary>uPaletteのEntryIdから色を設定する</summary>
         public static void SetColorFromEntryId(this Graphic graphic, ColorEntryId colorEntryId)
         {
@@ -22,6 +25,6 @@ namespace MittaUI.Runtime.Extension
             if (PaletteStore.Instance.ColorPalette.TryGetActiveValue(colorEntryId.Value, out var colorProperty))
                 graphic.color = colorProperty.Value;
         }
+#endif
     }
 }
-#endif

--- a/MittaUI.Runtime/MittaUI.Runtime.asmdef
+++ b/MittaUI.Runtime/MittaUI.Runtime.asmdef
@@ -6,7 +6,10 @@
         "GUID:45481c1a5703e4b4db8cfbe8316a40db",
         "GUID:77221876cc6b8244180b96e320b1bcd4",
         "GUID:dc47925d1a5fa2946bdd37746b2b5d48",
-        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:3b570a5146f9d4f0fa107ed4559471a3",
+        "GUID:3979491890dc7cd468c94d618fdf8506",
+        "GUID:029c1c1b674aaae47a6841a0b89ad80e"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -25,6 +28,11 @@
             "name": "com.harumak.upalette",
             "expression": "",
             "define": "MITTAUI_USE_UPALETTE"
+        },
+        {
+            "name": "com.annulusgames.lit-motion",
+            "expression": "",
+            "define": "MITTAUI_USE_LITMOTION"
         }
     ],
     "noEngineReferences": false

--- a/MittaUI.Runtime/TweenProvider.meta
+++ b/MittaUI.Runtime/TweenProvider.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2566a9768aba4d4dab68849ddc1d60e4
+timeCreated: 1714985975

--- a/MittaUI.Runtime/TweenProvider/TweenProvider.cs
+++ b/MittaUI.Runtime/TweenProvider/TweenProvider.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+#if MITTAUI_USE_DOTWEEN && UNITASK_DOTWEEN_SUPPORT
+using DG.Tweening;
+#endif
+
+#if MITTAUI_USE_LITMOTION
+using LitMotion;
+#endif
+
+namespace MittaUI.Runtime.TweenProvider
+{
+    public static class TweenProvider
+    {
+        public static async UniTask Tween(float from, float to, float duration, Action<float> onUpdate,
+            Action onComplete = null, CancellationToken ct = default)
+        {
+#if MITTAUI_USE_LITMOTION
+            await TweenLitMotion(from, to, duration, onUpdate, onComplete, ct);
+#elif MITTAUI_USE_DOTWEEN && UNITASK_DOTWEEN_SUPPORT
+            await TweenDoTween(from, to, duration, onUpdate, onComplete, ct);
+#else
+            await TweenPureUpdate(from, to, duration, onUpdate, onComplete, ct);
+#endif
+        }
+
+        public static async UniTask Move(Vector3 from, Vector3 to, float duration, Transform target,
+            Action onComplete = null,
+            CancellationToken ct = default)
+        {
+            await Tween(0, 1, duration, t => { target.position = Vector3.Lerp(from, to, t); }, onComplete, ct);
+        }
+
+        private static async UniTask TweenPureUpdate(float from, float to, float duration, Action<float> onUpdate,
+            Action onComplete = null, CancellationToken ct = default)
+        {
+            float time = 0;
+            while (time < duration)
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                time += Time.deltaTime;
+                onUpdate.Invoke(Mathf.Lerp(from, to, time / duration));
+                await UniTask.Yield();
+            }
+        }
+
+
+# if MITTAUI_USE_LITMOTION
+        private static async UniTask TweenLitMotion(float from, float to, float duration, Action<float> onUpdate,
+            Action onComplete = null, CancellationToken ct = default)
+        {
+            var tween = LMotion.Create(from, to, duration)
+                .Bind(onUpdate);
+
+            await tween.ToUniTask(ct);
+
+            if (onComplete != null)
+            {
+                onComplete();
+            }
+        }
+#endif
+
+#if MITTAUI_USE_DOTWEEN && UNITASK_DOTWEEN_SUPPORT
+        private static async UniTask TweenDoTween(float from, float to, float duration, Action<float> onUpdate,
+            Action onComplete = null, CancellationToken ct = default)
+        {
+            var tween = DOTween.To(() => from, x => onUpdate(x), to, duration);
+            await tween.ToUniTask(cancellationToken: ct);
+            onComplete?.Invoke();
+        }
+#endif
+
+        public static async UniTask FadeAsync(this CanvasGroup graphic, float targetAlpha, float duration,
+            CancellationToken ct = default)
+        {
+            var alpha = graphic.alpha;
+            await Tween(alpha, targetAlpha, duration, x => graphic.alpha = x, ct: ct);
+        }
+
+        public static async UniTask FadeAsync(this Graphic graphic, float targetAlpha, float duration,
+            CancellationToken ct = default)
+        {
+            // TODO ラムダ式で変数キャプチャしてるのでパフォーマンス悪い、いい感じにする
+            var color = graphic.color;
+            await Tween(color.a, targetAlpha, duration, x =>
+            {
+                color.a = x;
+                graphic.color = color;
+            }, ct: ct);
+        }
+    }
+}

--- a/MittaUI.Runtime/TweenProvider/TweenProvider.cs.meta
+++ b/MittaUI.Runtime/TweenProvider/TweenProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: de61d64a7b414f4694edb4ad2ed9ef27
+timeCreated: 1714986013


### PR DESCRIPTION
TinyTween的なやつの実装っす

現状対応してるのは
- LitMotion
- DOTween
- オラオラTween
の3つとなっております

また、DOTweenに関してはUPM経由で入れない(のが一般的)なので、
UniTaskみたいに ``MITTANUI_USE_DOTWEEN`` をScripting Define Symbols に追加することになっております