### PR TITLE
開発時にPartsのPrefab検索が聞かないバグを修正

### DIFF
--- a/Assets/Plugins/MittaUI/MittaUI.Editor/Utility/InstantiatePrefabWindow.cs
+++ b/Assets/Plugins/MittaUI/MittaUI.Editor/Utility/InstantiatePrefabWindow.cs
@@ -12,10 +12,15 @@ namespace MittaUI.Editor.Utility
     public class MyMenuItems
     {
         [MenuItem("GameObject/MittaUI", false, 0)]
-        static void Execute() => InstantiatePrefabWindow.Open("Packages/com.mitta.mitta-ui/MittaUI.Runtime/Prefabs");
+        static void Execute() => InstantiatePrefabWindow.Open(
+#if MITTAUI_RELEASE
+            "Packages/com.mitta.mitta-ui/MittaUI.Runtime/Prefabs"
+#else
+            "Assets/Plugins/MittaUI/MittaUI.Runtime/Prefabs"
+#endif
+        );
     }
 
-    
     /// <summary>
     /// 指定したディレクトリ配下を対象にした Prefab 一覧を表示し、選択した Prefab を配置するメニューウィンドウ
     /// </summary>

--- a/Assets/Plugins/MittaUI/MittaUI.Runtime/MittaUI.Runtime.asmdef
+++ b/Assets/Plugins/MittaUI/MittaUI.Runtime/MittaUI.Runtime.asmdef
@@ -33,6 +33,11 @@
             "name": "com.annulusgames.lit-motion",
             "expression": "",
             "define": "MITTAUI_USE_LITMOTION"
+        },
+        {
+            "name": "com.mitta.ui",
+            "expression": "",
+            "define": "MITTAUI_RELEASE"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
PJ構成を変えたため、開発時のみPrefab検索Windowが死んでますた
それの対応どすえ
![image](https://github.com/m-Mons/MittaUI/assets/64909026/7c881caa-8abe-48fe-8c24-dffe071241b7)
